### PR TITLE
feat(room): add voting interface and participant lists

### DIFF
--- a/frontend/src/components/voting/ObserversList.vue
+++ b/frontend/src/components/voting/ObserversList.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  participants: {
+    type: Object,
+    required: true,
+    validator: (value) =>
+      Object.values(value).every((p) => "nickname" in p && "role" in p),
+  },
+});
+
+const observers = computed(() =>
+  Object.entries(props.participants)
+    .filter(([, participant]) => participant.role === "observer")
+    .sort((a, b) => a[1].nickname.localeCompare(b[1].nickname))
+);
+</script>
+
+<template>
+  <div class="voter-list">
+    <div v-for="[id, participant] in observers" :key="id" class="voter-item">
+      <span class="nickname">{{ participant.nickname }}</span>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/voting/ResultsOverlay.vue
+++ b/frontend/src/components/voting/ResultsOverlay.vue
@@ -1,0 +1,11 @@
+<template>
+  <div>
+    <label>Общая оценка:</label>
+    <div><span></span> ч.</div>
+    <div>
+      <button>Перезапустить</button>
+      <button>Далее</button>
+      <button>Завершить</button>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/voting/VotersList.vue
+++ b/frontend/src/components/voting/VotersList.vue
@@ -1,0 +1,37 @@
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  participants: {
+    type: Object,
+    required: true,
+    validator: (value) =>
+      Object.values(value).every((p) => "nickname" in p && "role" in p),
+  },
+  votes: {
+    type: Object,
+    required: true,
+  },
+});
+
+const voters = computed(() =>
+  Object.entries(props.participants)
+    .filter(([, participant]) => participant.role === "voter")
+    .sort((a, b) => a[1].nickname.localeCompare(b[1].nickname))
+);
+</script>
+
+<template>
+  <div class="voter-list">
+    <div v-for="[id, participant] in voters" :key="id" class="voter-item">
+      <span class="nickname">{{ participant.nickname }}</span>
+      <span
+        class="vote-indicator"
+        :class="{ 'has-voted': votes[id] }"
+        aria-label="Статус голосования"
+      >
+        {{ votes[id] ? "✓" : "⌛" }}
+      </span>
+    </div>
+  </div>
+</template>

--- a/frontend/src/components/voting/VotingForm.vue
+++ b/frontend/src/components/voting/VotingForm.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <label for="guess">Ваша оценка:</label>
+    <div>
+      <input
+        v-model="guessValue"
+        id="guess"
+        type="number"
+        min="0"
+        placeholder="Введите часы"
+      />
+      ч.
+    </div>
+    <button @click="handleSubmit" :disabled="!isValid">OK</button>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed } from "vue";
+
+const emit = defineEmits(["vote"]);
+
+const guessValue = ref("");
+
+const isValid = computed(() => {
+  return Number(guessValue.value) > 0;
+});
+
+const handleSubmit = () => {
+  if (!isValid.value) return;
+
+  emit("vote", Number(guessValue.value));
+  guessValue.value = "";
+};
+</script>


### PR DESCRIPTION
## Что сделано  
- Интеграция компонентов голосования в `RoomPage`:  
  - `VotingForm` — форма для отправки голоса.  
  - `VotersList` — список участников с индикацией статуса голоса.  
  - `ObserversList` — список наблюдателей.  
  - `ResultsOverlay` — заглушка для отображения результатов.  
- Реализовано управление состоянием голосования:  
  - Состояния комнаты: `waiting`, `voting`, `waiting_players`, `results`.  
  - Переходы между этапами: старт голосования (`startVoting`), обработка голосов (`handleVote`).  
  - Проверка завершения голосования (`allVoted`).  
- Добавлены моковые данные для демонстрации:  
  - Участники (voter/observer).  
  - Текущий пользователь (`currentUserId`).  

## Следующие шаги  
- Подключение к API Django.
- Реализация полного дизайна интерфейса.  
- Добавление обработки ошибок.