### PR TITLE
feat: implement participant presence monitor and сhannels mapping

### DIFF
--- a/clocks/ws/services/room_online_tracker.py
+++ b/clocks/ws/services/room_online_tracker.py
@@ -1,0 +1,43 @@
+from typing import Dict
+
+from django.core.cache import cache
+
+
+class RoomOnlineTracker:
+    _CACHE_PREFIX = "online"
+    _DEFAULT_TTL = 60 * 60 * 5
+    @classmethod
+    def _make_key(cls, room_id: int) -> str:
+        return f"{cls._CACHE_PREFIX}:room_{room_id}"
+
+    @classmethod
+    def _set_user_status(cls, user_uuid, room_id, status: bool) -> None:
+        room_key = cls._make_key(room_id)
+        participants: Dict[str, bool] = cache.get(room_key, {})
+        participants[user_uuid] = status
+        cache.set(room_key, participants, cls._DEFAULT_TTL)
+
+    @classmethod
+    def set_user_offline(cls, user_uuid: str, room_id: int) -> None:
+        cls._set_user_status(user_uuid, room_id, False)
+
+    @classmethod
+    def set_user_online(cls, user_uuid: str, room_id: int) -> None:
+        cls._set_user_status(user_uuid, room_id, True)
+
+    @classmethod
+    def get_room_participants(cls, room_id: int) -> Dict[str, bool]:
+        room_key = cls._make_key(room_id)
+        return cache.get(room_key, {})
+
+    @classmethod
+    def clean_room_participant(cls, room_id: int) -> None:
+        room_key = cls._make_key(room_id)
+        with cache.lock(room_key):
+            cache.set(room_key, {}, cls._DEFAULT_TTL)
+
+    @classmethod
+    def refresh_ttl(cls, room_id: int) -> None:
+        room_key = cls._make_key(room_id)
+        if cache.has_key(room_key):
+            cache.touch(room_key, cls._DEFAULT_TTL)

--- a/clocks/ws/services/user_channel_tracker.py
+++ b/clocks/ws/services/user_channel_tracker.py
@@ -1,0 +1,70 @@
+from enum import Enum
+from typing import Optional, Dict, Set
+
+from django.core.cache import cache
+
+
+class KeyType(Enum):
+    CHANNEL = "channel"
+    ROOM_PARTICIPANTS = "room_participants"
+
+
+class UserChannelTracker:
+    _CACHE_PREFIX = "ws_sessions"
+    _DEFAULT_TTL = 60 * 60 * 2
+
+    @classmethod
+    def _make_key(cls, key_type: KeyType, identifier: str) -> str:
+        return f"{cls._CACHE_PREFIX}:{key_type.value}:{identifier}"
+
+    @classmethod
+    def add_participant(cls, channel_name: str, user_uuid: str, room_id: int) -> None:
+        chan_key = cls._make_key(KeyType.CHANNEL, channel_name)
+        part_key = cls._make_key(KeyType.ROOM_PARTICIPANTS, str(room_id))
+
+        participants: Set[str] = cache.get(part_key, set())
+
+        if channel_name not in participants:
+            participants.add(channel_name)
+            cache.set(part_key, participants, cls._DEFAULT_TTL)
+
+        cache.set(chan_key, {"user_uuid": user_uuid, "room_id": room_id}, cls._DEFAULT_TTL)
+
+    @classmethod
+    def remove_participant(cls, channel_name: str) -> None:
+        chan_key = cls._make_key(KeyType.CHANNEL, channel_name)
+        data = cache.get(chan_key)
+        if not data:
+            return
+
+        room_id = data["room_id"]
+        part_key = cls._make_key(KeyType.ROOM_PARTICIPANTS, str(room_id))
+
+        participants: Set[str] = cache.get(part_key, set())
+        participants.discard(channel_name)
+        if participants:
+            cache.set(part_key, participants, cls._DEFAULT_TTL)
+        else:
+            cache.delete(part_key)
+
+        cache.delete(chan_key)
+
+    @classmethod
+    def get_participant_info(cls, channel_name: str) -> Optional[Dict[str, str]]:
+        chan_key = cls._make_key(KeyType.CHANNEL, channel_name)
+        return cache.get(chan_key)
+
+    @classmethod
+    def get_room_participants(cls, room_id: int) -> Set[str]:
+        part_key = cls._make_key(KeyType.ROOM_PARTICIPANTS, str(room_id))
+        return set(cache.get(part_key, set()))
+
+    @classmethod
+    def refresh_ttl(cls, channel_name: str) -> None:
+        info = cls.get_participant_info(channel_name)
+        if not info:
+            return
+        chan_key = cls._make_key(KeyType.CHANNEL, channel_name)
+        part_key = cls._make_key(KeyType.ROOM_PARTICIPANTS, str(info["room_id"]))
+        cache.touch(chan_key, cls._DEFAULT_TTL)
+        cache.touch(part_key, cls._DEFAULT_TTL)


### PR DESCRIPTION
## What's done
Implemented a system to track users' presence in rooms in real time:
- Added `RoomOnlineTracker` to monitor the online status of participants
- Implemented `UserChannelTracker` to link websocket channels to users

## Key changes
- 🟢 **RoomOnlineTracker**
  - Tracks online status via Django cache
  - TTL, automatic room cleanup after 5 hours of inactivity
- 🔗 **UserChannelTracker**
  - Bidirectional mapping: channel ↔ (user, room)
  - TTL update support for active connections